### PR TITLE
V0.2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.md') as f:
 
 setup(
     name='wagtail_references',
-    version='0.2.2',
+    version='0.2.3',
     description='BibTeX references for Wagtail',
     long_description=readme_text,
     long_description_content_type="text/markdown",

--- a/wagtail_references/models.py
+++ b/wagtail_references/models.py
@@ -1,6 +1,7 @@
+import bibtexparser
 import jsonfield
 import logging
-import bibtexparser
+import re
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -170,3 +171,9 @@ class Reference(AbstractReference):
         super().clean()
         if not Reference._slug_is_available(self.slug):
             raise ValidationError({'slug': _("This slug is already in use")})
+
+    @property
+    def bibtex_string(self):
+        """ Returns teh bibtex as a single string with no line breaks
+        """
+        return re.sub(r'[\n\r]+', '', self.bibtex)

--- a/wagtail_references/templates/wagtail_references/references/results.html
+++ b/wagtail_references/templates/wagtail_references/references/results.html
@@ -15,13 +15,30 @@
         <h2>{% trans "Latest references" %}</h2>
     {% endif %}
 
+    <div id="output">
+    </div>
+
+
+    <!-- Using citation.js https://citation.js.org/api/tutorial-getting_started.html -->
+    <script src="https://cdn.jsdelivr.net/npm/citation-js" type="text/javascript"></script>
+    <script type="text/javascript">
+      const Cite = require('citation-js')
+      function renderToDiv(inputBibtex, divId) {
+          const citation = new Cite(inputBibtex)
+          const outputHtml = citation.format('bibliography', {
+            format: 'html',
+            template: 'apa',
+            lang: 'en-US'
+          })
+          outputDiv = document.getElementById(divId)
+          outputDiv.innerHTML = outputHtml
+      }
+    </script>
+
     <ul class="listing horiz references">
         {% for reference in references %}
             <li>
-                <a class="image-choice" title="{% if collections %}{{ reference.collection.name }} » {% endif %}{{ reference.slug }}" href="{% url 'wagtailreferences:edit' reference.id %}">
-                    {% include "wagtail_references/references/results_reference.html" %}
-                    <h3>{{ reference.bibtex|ellipsistrim:60 }}</h3>
-                </a>
+                {% include "wagtail_references/references/results_reference.html" %}
             </li>
         {% endfor %}
     </ul>

--- a/wagtail_references/templates/wagtail_references/references/results_reference.html
+++ b/wagtail_references/templates/wagtail_references/references/results_reference.html
@@ -8,9 +8,19 @@
  This behaviour caused a confusing error on the references listing view where it
  would go blank if one of the references was invalid.
 
- Separating the refereence rendering code into this file allows us to limit Django's
+ Separating the reference rendering code into this file allows us to limit Django's
  crash/blanking behaviour to a single reference so the listing can still be used when
  the issue occurs.
 {% endcomment %}
+{% load wagtailimages_tags wagtailadmin_tags %}
+{% load i18n %}
+<a class="image-choice" title="{% if collections %}{{ reference.collection.name }} » {% endif %}{{ reference.slug }}" href="{% url 'wagtailreferences:edit' reference.id %}">
+    <h3><strong>Slug (citation key):</strong> {{ reference.slug }}</h3>
+    <h3><strong>Type:</strong> {{ reference.bibtype }}</h3>
+{#    <h3><strong>Bibtex:</strong> {{ reference.bibtex|ellipsistrim:140 }}</h3>#}
+    <h3><strong>Preview:</strong></h3>
+    <div id="{{ reference.slug }}"></div>
+</a>
+<script type="text/javascript"> renderToDiv("{{ reference.bibtex_string }}", "{{ reference.slug }}") </script>
 
-<div class="image">{{ reference.slug }}</div>
+


### PR DESCRIPTION
## Features:
Improved rendering of the references where they appear in a list. Rendering is now:
- **more robust** since an entire single reference is rendered in one include block. If rendering a single one goes wrong, the rest don't fail.
- **prettier** ``citation.js`` is used in teh template to convert the bibtex to apa-style citations in HTML. So you get to see how they'll actually be rendered on the front end.

## Docs:
Updated the readme to include usage examples:
- How to use ``citation.js`` in template rendering
- A react component that converts and displays the citation
- Removed the roadmap lines for things I just did! Yay!